### PR TITLE
Add convenience docker compose helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,21 @@ clean:
 	$(DOCKER_COMPOSE) down
 
 fclean: clean
-        @if [ -f ./clean.sh ]; then sudo ./clean.sh; fi
-        docker volume prune -f
+	@if [ -f ./clean.sh ]; then sudo ./clean.sh; fi
+	docker volume prune -f
 	# If you want to remove images entirely, uncomment:
 	# docker image prune -a -f
 	docker network prune -f
 
 re: fclean all
 
-.PHONY: all clean fclean re
+start:
+	$(DOCKER_COMPOSE) up -d
+
+stop:
+	$(DOCKER_COMPOSE) down
+
+logs:
+	$(DOCKER_COMPOSE) logs -f
+
+.PHONY: all clean fclean re start stop logs

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ The stack consists of four services defined in `docker-compose.yml`:
    make
    ```
 
+   After the initial build you can start and stop the stack using the helper
+   targets:
+
+   ```bash
+   make start    # docker compose up -d
+   make stop     # docker compose down
+   make logs     # follow container logs
+   ```
+
    The first launch installs Laravel into `backend/` and creates a Vue project in `frontend/` if those directories are empty.
 
 4. **Access the applications**


### PR DESCRIPTION
## Summary
- add `start`, `stop` and `logs` to `Makefile`
- document the new targets in the README

## Testing
- `bash -n backend/entrypoint.sh frontend/entrypoint.sh`
- `make start` *(fails: `docker` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68415052e1548325b759167aab661fdc